### PR TITLE
The word bank storage wraps when a scrollbar would appear

### DIFF
--- a/local/P.css
+++ b/local/P.css
@@ -169,3 +169,7 @@ body {
   background-color: rgb(24, 24, 24);
   transform: scale(2);
 }
+
+.wordBankWrap {
+  flex-wrap: wrap;
+}

--- a/local/P.html
+++ b/local/P.html
@@ -153,7 +153,7 @@
             
             
             </div>
-            <div class="btn-group" role="group" aria-label="Bottom Text Entry Buttons" id="wordBankStorage" style="visibility:visible">
+            <div class="btn-group wordBankWrap" role="group" aria-label="Bottom Text Entry Buttons" id="wordBankStorage" style="visibility:visible">
               <!--<button type="button" class="btn btn-primary">a</button>
               <button type="button" class="btn btn-primary">b</button>
               <button type="button" class="btn btn-primary">c</button>-->


### PR DESCRIPTION
Has a small issue where the last word's delete button will appear on the next line, but it is likely better than having horizontal scrollbars appear when the words reach a certain point.